### PR TITLE
ENH: Add select methods for IPC

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -140,3 +140,17 @@ class Connection(object):
         # type: () -> Cursor
         """Create a new :class:`Cursor` object attached to this connection."""
         return Cursor(self)
+
+    def select_ipc(self, operation):
+        """Execute a ``SELECT`` operation.
+        """
+        # TODO: figure out what `first_n` does, add to API
+        return self._client.sql_execute_df(
+            self._session, operation, first_n=-1)
+
+    def select_ipc_gpu(self, operation, device_id=0):
+        """Execute a ``SELECT`` operation.
+        """
+        # TODO: figure out what `first_n` does, add to API
+        return self._client.sql_execute_gpudf(
+            self._session, operation, device_id=device_id, first_n=-1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,3 +74,18 @@ def invalid_sql():
 @pytest.fixture
 def nonexistant_table():
     return _load_pickle(os.path.join(HERE, "data", "nonexistant_table.pkl"))
+
+
+@pytest.fixture(scope="session")
+def stocks(con):
+    drop = 'drop table if exists stocks;'
+    c = con.cursor()
+    c.execute(drop)
+    create = ('create table stocks (date_ text, trans text, symbol text, '
+              'qty int, price float, vol float);')
+    c.execute(create)
+    i1 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','RHAT',100,35.14,1.1);"
+    i2 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','GOOG',100,12.14,1.2);"
+
+    c.execute(i1)
+    c.execute(i2)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,10 +2,12 @@
 Tests that rely on a server running
 """
 import pytest
-from mapd.ttypes import TMapDException
+from mapd.ttypes import TMapDException, TGpuDataFrame
 
 from pymapd import connect, ProgrammingError, DatabaseError
 from pymapd.cursor import Cursor
+
+from .utils import no_gpu
 
 # XXX: Make it hashable to silence warnings; see if this can be done upstream
 # This isn't a huge deal, but our testing context mangers for asserting
@@ -40,3 +42,13 @@ class TestIntegration:
         result = con.execute("drop table if exists FOO;")
         result = con.execute("create table FOO (a int);")
         assert isinstance(result, Cursor)
+
+    @pytest.mark.skipif(no_gpu, reason="No GPU available")
+    def test_select_ipc(self, con, stocks):
+        result = con.select_ipc("select qty, price from stocks")
+        assert isinstance(result, TGpuDataFrame)
+
+    @pytest.mark.skipif(no_gpu, reason="No GPU available")
+    def test_select_ipc_gpu(self, con, stocks):
+        result = con.select_ipc_gpu("select qty, price from stocks")
+        assert isinstance(result, TGpuDataFrame)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+def no_gpu():
+    """Detect if don't have numba and a GPU available"""
+    try:
+        from numba import cuda
+
+        try:
+            cuda.select_device(0)
+        except cuda.cudadrv.error.CudaDriverError:
+            return True
+    except ImportError:
+        return True
+    return False


### PR DESCRIPTION
Allows for select statements that returns memory handles, rather than a result
set. ATM this is implemented on the `connection` object, rather than the cursor.
I'm not sure which is more appropriate. For it to belong on the `Cursor` object,
I think we would need to bring the parsing code from pygdf into pymapd, so we
can parse the result into a result set, and return an Iterator over that.