### PR TITLE
ENH: Add load_table_binary

### DIFF
--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -1,7 +1,8 @@
 """
 Internal helpers for loading data
 """
-from mapd.ttypes import TStringRow, TStringValue
+from itertools import cycle
+from mapd.ttypes import TStringRow, TStringValue, TRow, TDatumVal, TDatum
 
 
 def _build_input_rows(data):
@@ -11,3 +12,43 @@ def _build_input_rows(data):
         input_row.cols = [TStringValue(str(x)) for x in row]
         input_data.append(input_row)
     return input_data
+
+
+def _build_input_rows_binary(data, types):
+    try:
+        import pandas as pd
+    except ImportError:
+        pass
+    else:
+        if isinstance(data, pd.DataFrame):
+            data = data.itertuples(index=False)
+
+    types = cycle(types)
+
+    binary_rows = []
+    for row in data:
+        trow = []
+        for col, t in zip(row, types):
+            if t == 'INT':
+                trow.append(TDatum(TDatumVal(int_val=col)))
+            elif t == 'FLOAT':
+                trow.append(TDatum(TDatumVal(real_val=col)))
+            elif t == 'STR':
+                trow.append(TDatum(TDatumVal(str_val=col)))
+        binary_rows.append(TRow(trow))
+    return binary_rows
+
+
+def _infer_type(column):
+    from pandas.api.types import (is_any_int_dtype,
+                                  is_float_dtype,
+                                  is_string_dtype)
+
+    if is_any_int_dtype(column):
+        return 'int'
+    elif is_float_dtype(column):
+        return 'float'
+    elif is_string_dtype(column):
+        return 'string'
+    else:
+        raise TypeError("Unsupported type {}".format(type(column)))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -227,11 +227,12 @@ class TestExtras(object):
         ]
         assert result == expected
 
-    def test_load_table(self, con, empty_table):
+    @pytest.mark.parametrize('binary', [True, False])
+    def test_load_table(self, binary, con, empty_table):
         data = [(1, 1.1, 'a'),
                 (2, 2.2, '2'),
                 (3, 3.3, '3')]
-        con.load_table(empty_table, data)
+        con.load_table(empty_table, data, binary=binary)
         result = sorted(con.execute("select * from {}".format(empty_table)))
         assert len(result) == 3
         assert data[0][0] == result[0][0]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,5 @@
-from pymapd._loaders import _build_input_rows
-from mapd.MapD import TStringRow, TStringValue
+from pymapd._loaders import _build_input_rows, _build_input_rows_binary
+from mapd.MapD import TStringRow, TStringValue, TRow, TDatum, TDatumVal
 
 
 class TestLoaders(object):
@@ -11,5 +11,19 @@ class TestLoaders(object):
                                      TStringValue(str_val='a', is_null=None)]),
                     TStringRow(cols=[TStringValue(str_val='2', is_null=None),
                                      TStringValue(str_val='b', is_null=None)])]
+
+        assert result == expected
+
+    def test_build_input_rows_binary(self):
+        types = ['INT', 'FLOAT', 'STR']
+        data = [(1, 1.1, '1'), (2, 2.2, '2')]
+        result = _build_input_rows_binary(data, types)
+
+        expected = [TRow(cols=[TDatum(val=TDatumVal(int_val=1), is_null=None),
+                               TDatum(val=TDatumVal(real_val=1.1), is_null=None),   # noqa
+                               TDatum(val=TDatumVal(str_val='1'), is_null=None)]),  # noqa
+                    TRow(cols=[TDatum(val=TDatumVal(int_val=2), is_null=None),
+                               TDatum(val=TDatumVal(real_val=2.2), is_null=None),   # noqa
+                               TDatum(val=TDatumVal(str_val='2'), is_null=None)])]  # noqa
 
         assert result == expected


### PR DESCRIPTION
This adds the option to load data using the `load_table_binary` client
method by passing `binary=True` to `Connection.load_table`. The early benchmarks
aren't all that impressive. Loading 10,000 rows into a table of
(int, float, str) takes

```python
%time con.load_table('baz', data, binary=True)
CPU times: user 1.39 s, sys: 74.9 ms, total: 1.47 s
Wall time: 2.65 s
```

```python
%time con.load_table('baz', data, binary=False)
CPU times: user 1.03 s, sys: 52.8 ms, total: 1.08 s
Wall time: 2.1 s
```

So slightly slower. Some very early profiling indicates that (for this dataset)
we spend about 75% of the time converting from a list of tuples to a list of
Thrift structures (see `_build_input_rows_binary`). The remainder is spent
in a send/recv with the MapD server.

Here's the scaling behavior of `load_table` over a range of rows (same structure of int, str, float).

![load-binary-scaling](https://user-images.githubusercontent.com/1312546/29588939-f353c69c-8758-11e7-9151-dfedce54cd97.png)

<details>
```python
# scaling benchmark
import pandas as pd
import numpy as np
from pymapd import connect
from timeit import default_timer as timer

con = connect(user="mapd", password="HyperInteractive", host="localhost",
              dbname="mapd")
Ns = [10**i for i in range(1, 7)]
timings = []

for N in Ns:

    df = pd.DataFrame({
        "a": np.random.randint(0, 10, size=(N,)),
        "b": np.random.uniform(0, 10, size=(N,)),
        "c": np.random.choice(list('abcdefg'), size=(N))
    })
    data = list(df.itertuples(index=False))
    
    name = 'baz'
    con.execute("drop table if exists {};".format(name))
    con.execute("create table {} (a int, b float, c text);".format(name))
    t0 = timer()
    con.load_table("baz", data)
    t1 = timer()
    print(N, t1 - t0)
    timings.append(t1 - t0)
```
</details>
