### PR TITLE
PKG: require explicit versions of thrift, pyarrow

### DIFF
--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -29,7 +29,7 @@ source activate test-environment
 
 conda install -q \
       six \
-      thrift \
+      thrift=0.10.0 \
       coverage \
       flake8 \
       pytest \
@@ -37,8 +37,8 @@ conda install -q \
       pytest-mock \
       sqlalchemy \
       mock \
-      pyarrow \
-      arrow-cpp \
+      pyarrow=0.7.1 \
+      arrow-cpp=0.7.1 \
       cython \
       numpy \
       pandas

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -32,7 +32,7 @@ conda install -q \
       thrift=0.10.0 \
       coverage \
       flake8 \
-      pytest \
+      pytest=3.3.1 \
       pytest-cov \
       pytest-mock \
       sqlalchemy \

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
 - thrift=0.10.0
 - numpydoc
 - cython
-- pyarrow
-- arrow-cpp
+- pyarrow=0.7.1
+- arrow-cpp=0.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=0
 
 [flake8]
-exclude = tests/data,mapd,docs,benchmarks,scripts
+exclude = tests/data,mapd,docs,benchmarks,scripts,.eggs
 
 [tool:pytest]
 addopts = -rsx -v

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['six', 'thrift', 'sqlalchemy']
+install_requires = ['six', 'thrift == 0.10.0', 'sqlalchemy']
 
 # Optional Requirements
 
@@ -27,7 +27,7 @@ doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
 test_requires = ['coverage', 'pytest', 'pytest-mock']
 dev_requires = doc_requires + test_requires
 gpu_requires = ['pygdf', 'libgdf']
-arrow_requires = ['pyarrow']
+arrow_requires = ['pyarrow == 0.7.1']
 complete_requires = dev_requires + gpu_requires + arrow_requires
 
 if sys.version_info.major == 2:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = ['six', 'thrift == 0.10.0', 'sqlalchemy']
 
 
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
-test_requires = ['coverage', 'pytest', 'pytest-mock']
+test_requires = ['coverage', 'pytest == 3.3.1', 'pytest-mock']
 dev_requires = doc_requires + test_requires
 gpu_requires = ['pygdf', 'libgdf']
 arrow_requires = ['pyarrow == 0.7.1']


### PR DESCRIPTION
Thrift and pyarrow are not fully backwards compatible, so we need to
explictly set the expected versions to use in them.

The Thrift bindings only work with the version of Thrift used to
generate them.

This resolves various issues introduced by the releases of thrift 0.11.0
and pyarrow 0.8.0.