### PR TITLE
Deallocation: Implicit TDF assignment

### DIFF
--- a/pymapd/_mutators.py
+++ b/pymapd/_mutators.py
@@ -1,0 +1,33 @@
+"""
+Setter and Getter for TDataFrame
+"""
+
+
+def set_tdf(self, tdf):
+    # type: () -> None
+    """Assigns a TDataFrame to pygdf/pandas Dataframe
+
+        Parameters
+        ----------
+        tdf : TDataFrame
+            A SQL select statement
+
+        Example
+        -------
+        >>> df.set_tdf(tdf)
+        """
+    self._tdf = tdf
+
+
+def get_tdf(self):
+    """Returns assigned TDataFrame.
+
+        Example
+        -------
+        >>> df.get_tdf()
+        TDataFrame(sm_handle=b'\xa30q%', sm_size=632, df_handle=b'\x90a>
+        \x06\x00\x00\x00\x00\xe0\xe6\x00\x00\x00\x00\x00\x00\xe0|E\x00\x00
+        \x00\xca\x01\xd0\xc1"\x03\x00\\', df_size=4553952)
+        """
+
+    return self._tdf

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -313,10 +313,10 @@ class Connection(object):
         df_buf = load_buffer(tdf.df_handle, tdf.df_size)
 
         schema = _load_schema(sm_buf)
-        df = _load_data(df_buf, schema)
+        df = _load_data(df_buf, schema, tdf)
         return df
 
-    def deallocate_ipc_gpu(self, device_id=0):
+    def deallocate_ipc_gpu(self, df, device_id=0):
         # type: () -> None
         """Deallocate a DataFrame using GPU memory.
 
@@ -326,13 +326,15 @@ class Connection(object):
             GPU which contains TDataFrame
         """
 
+        tdf = df.get_tdf()
         result = self._client.deallocate_df(
-                session=self._session, df=self._tdf,
+                session=self._session,
+                df=tdf,
                 device_type=TDeviceType.GPU,
                 device_id=device_id)
         return result
 
-    def deallocate_ipc(self, device_id=0):
+    def deallocate_ipc(self, df, device_id=0):
         # type: () -> None
         """Deallocate a DataFrame using CPU shared memory.
 
@@ -341,25 +343,13 @@ class Connection(object):
         device_id : int
             GPU which contains TDataFrame
         """
-
+        tdf = df.get_tdf()
         result = self._client.deallocate_df(
-                session=self._session, df=self._tdf,
+                session=self._session,
+                df=tdf,
                 device_type=TDeviceType.CPU,
                 device_id=device_id)
         return result
-
-    @property
-    def get_tdf(self):
-        """Returns latest TDataFrame.
-
-        Example
-        -------
-        >>> con.get_tdf()
-        TDataFrame(sm_handle=b'\xa30q%', sm_size=632, df_handle=b'\x90a>
-        \x06\x00\x00\x00\x00\xe0\xe6\x00\x00\x00\x00\x00\x00\xe0|E\x00\x00
-        \x00\xca\x01\xd0\xc1"\x03\x00\\', df_size=4553952)
-        """
-        return self._tdf
 
     # --------------------------------------------------------------------------
     # Convenience methods

--- a/tests/test_deallocate.py
+++ b/tests/test_deallocate.py
@@ -43,9 +43,9 @@ class TestDeallocate:
                                           -q -d MEMORY | \
                                           awk ' FNR == 11 { print $3 }' \
                                           ''', shell=True))
-        con.select_ipc_gpu('''select sepal_l, sepal_W,
+        df = con.select_ipc_gpu('''select sepal_l, sepal_W,
                                 petal_l, petal_w, species from iris''')
-        con.deallocate_ipc_gpu()
+        con.deallocate_ipc_gpu(df)
         amem = int(subprocess.check_output('''nvidia-smi -i 0 \
                                           -q -d MEMORY | \
                                           awk ' FNR == 11 { print $3 }' \
@@ -58,9 +58,9 @@ class TestDeallocate:
         con = self._connect()
         self._transact(con)
         bmem = int(subprocess.check_output('''ipcs -m | wc -l''', shell=True))
-        con.select_ipc('''select sepal_l, sepal_W,
+        df = con.select_ipc('''select sepal_l, sepal_W,
                                 petal_l, petal_w, species from iris''')
-        con.deallocate_ipc()
+        con.deallocate_ipc(df)
         amem = int(subprocess.check_output('''ipcs -m | wc -l''', shell=True))
         con.close()
 
@@ -71,22 +71,22 @@ class TestDeallocate:
         con = self._connect()
         self._transact(con)
 
-        con.select_ipc_gpu('select species from iris')
-        con.deallocate_ipc_gpu()
+        df = con.select_ipc_gpu('select species from iris')
+        con.deallocate_ipc_gpu(df)
 
         with pytest.raises(TMapDException) as te:
-            con.deallocate_ipc_gpu()
+            con.deallocate_ipc_gpu(df)
         assert 'Exception: current data frame' in str(te.value.error_msg)
 
     def test_ipc_raises_right_exception(self):
         con = self._connect()
         self._transact(con)
 
-        con.select_ipc('select sepal_l, sepal_W from iris')
-        con.deallocate_ipc()
+        df = con.select_ipc('select sepal_l, sepal_W from iris')
+        con.deallocate_ipc(df)
 
         with pytest.raises(TApplicationException) as ae:
-            con.deallocate_ipc()
+            con.deallocate_ipc(df)
         assert 'valid shm ID w/ given shm key' in str(ae.value.message)
 
     @pytest.mark.skipif(no_gpu(), reason="No GPU available")
@@ -95,8 +95,27 @@ class TestDeallocate:
         con1 = self._connect()
         self._transact(con)
 
-        con.select_ipc_gpu('select id from iris')
+        df = con.select_ipc_gpu('select id from iris')
         con.close()
         with pytest.raises(TMapDException) as te:
-            con1.deallocate_ipc_gpu()
+            con1.deallocate_ipc_gpu(df)
         assert 'Exception: current data frame' in str(te.value.error_msg)
+
+    def test_ipc_multiple_df(self):
+        con = self._connect()
+        self._transact(con)
+        bmem = int(subprocess.check_output('''ipcs -m | wc -l''', shell=True))
+        df1 = con.select_ipc('''select sepal_l, sepal_W,
+                                petal_l, petal_w, species from iris''')
+        df2 = con.select_ipc('''select sepal_l, sepal_W,
+                                petal_l, petal_w, species from iris''')
+        df3 = con.select_ipc('''select sepal_l, sepal_W,
+                                petal_l, petal_w, species from iris''')
+        con.deallocate_ipc(df1)
+        con.deallocate_ipc(df2)
+        con.deallocate_ipc(df3)
+
+        amem = int(subprocess.check_output('''ipcs -m | wc -l''', shell=True))
+        con.close()
+
+        assert amem == bmem


### PR DESCRIPTION
- [x] Bind mutators to `pygdf` and `pandas` instances to keep track of `tdf` for each df

- [x] Assign each `tdf` to its own `df` implicitly. 

- [x] Remove `get_tdf()` method from `Connection` object

WIP: Implicit Assignment of `df` for GPU and CPU `deallocation`

fixes #74 