### PR TITLE
Use a positional index when getting MapD types from objects

### DIFF
--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -51,7 +51,7 @@ def get_mapd_type_from_known(dtype):
 def get_mapd_type_from_object(data):
     """For cases where the type system mismatches"""
     try:
-        val = data.dropna()[0]
+        val = data.dropna().iloc[0]
     except IndexError:
         raise IndexError("Not any valid values to infer the type")
     if isinstance(val, six.string_types):


### PR DESCRIPTION
Currently, if `0` is not in the index then an error is returned.

```python-traceback
~/anaconda/envs/p6/lib/python3.6/site-packages/pymapd/_pandas_loaders.py in get_mapd_type_from_object(data)
     52     """For cases where the type system mismatches"""
     53     try:
---> 54         val = data.dropna()[0]
     55     except IndexError:
     56         raise IndexError("Not any valid values to infer the type")

...

KeyError: 0
```